### PR TITLE
fix(PropertyType): trim value before parse for fixup endline comment with '#'

### DIFF
--- a/core/src/main/java/org/ec4j/core/model/PropertyType.java
+++ b/core/src/main/java/org/ec4j/core/model/PropertyType.java
@@ -605,7 +605,7 @@ public class PropertyType<T> {
      * @return the {@link PropertyValue}
      */
     public PropertyValue<T> parse(String value) {
-        return parser.parse(name, value);
+        return parser.parse(name, value == null ? null : value.trim());
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
end_of_line = lf #some comment  ==>
```
Caused by: java.lang.RuntimeException: Unexpected parsed "lf " for enum org.ec4j.core.model.PropertyType$EndOfLineValue
    at org.ec4j.core.model.Property.getValueAs (Property.java:217)
    at org.ec4j.core.ResourceProperties.getValue (ResourceProperties.java:183)
    at org.ec4j.core.ResourceProperties.getValue (ResourceProperties.java:154)
    at org.ec4j.linters.TextLinter.process (TextLinter.java:136)
    at org.ec4j.maven.AbstractEditorconfigMojo.execute (AbstractEditorconfigMojo.java:247)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
```

charset = utf-8 #some comment ==>
```
Caused by: java.nio.charset.IllegalCharsetNameException: utf-8
    at java.nio.charset.Charset.checkName (Charset.java:315)
    at java.nio.charset.Charset.lookup2 (Charset.java:484)
    at java.nio.charset.Charset.lookup (Charset.java:464)
    at java.nio.charset.Charset.forName (Charset.java:528)
    at org.ec4j.core.Resource$Charsets.forName (Resource.java:294)
    at org.ec4j.maven.AbstractEditorconfigMojo.execute (AbstractEditorconfigMojo.java:233)
```